### PR TITLE
Fix the help link.

### DIFF
--- a/app/helpers/redmine_redcarpet_formatter/helper.rb
+++ b/app/helpers/redmine_redcarpet_formatter/helper.rb
@@ -4,8 +4,7 @@ module RedmineRedcarpetFormatter
 
     def wikitoolbar_for(field_id)
       heads_for_wiki_formatter
-      url = Redmine::Utils.relative_url_root +
-        Engines::RailsExtensions::AssetHelpers.plugin_asset_path('redmine_redcarpet_formatter', 'help', 'markdown_wiki_syntax.html')
+      url = Engines::RailsExtensions::AssetHelpers.plugin_asset_path('redmine_redcarpet_formatter', 'help', 'markdown_wiki_syntax.html')
       help_link = l(:setting_text_formatting) + ': ' +
         link_to(l(:label_help), url,
         :onclick => "window.open(\"#{url}\", \"\", \"resizable=yes, location=no, width=480, height=640, menubar=no, status=no, scrollbars=yes\"); return false;")


### PR DESCRIPTION
If Redmine is installed in a virtual directory (ie, redmine), the help link will point to "redmine/redmine/plugin_assets/redmine_redcarpet_formatter/help/markdown_wiki_syntax.html".
