### PR TITLE
Section editing is broken in ruby 1.9.3

### DIFF
--- a/lib/redmine/wiki_formatting/markdown/formatter.rb
+++ b/lib/redmine/wiki_formatting/markdown/formatter.rb
@@ -63,7 +63,7 @@ module Redmine
           selected_level = 0
           header_count = 0
 
-          @text.each do |line|
+          @text.each_line do |line|
 
             if line =~ /^(~~~|```)/
               pre = pre == :pre ? :none : :pre


### PR DESCRIPTION
Section editing crashes with this error (after removing some backtrace silencers that are normally active):

```
NoMethodError (undefined method `each' for #<String:0x00000006470df0>):
  plugins/redmine_redcarpet_formatter/lib/redmine/wiki_formatting/markdown/formatter.rb:66:in `extract_sections'
  plugins/redmine_redcarpet_formatter/lib/redmine/wiki_formatting/markdown/formatter.rb:42:in `get_section'
  app/controllers/wiki_controller.rb:118:in `edit'
```

I turns out the fix was easy, though. Ruby 1.8.7's [String#each](http://www.ruby-doc.org/core-1.8.7/String.html#method-i-each) was being used, which does not exist in 1.9.3; you have to use the more specific [String#each_line](http://www.ruby-doc.org/core-1.9.3/String.html#method-i-each_line).
