### PR TITLE
Syntax-highlighting by pygments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem "redcarpet"
+gem "pygments.rb", ">= 0.5.0"

--- a/README.markdown
+++ b/README.markdown
@@ -25,6 +25,7 @@ Prerequisites
 
 *  Redmine 1.x, Remine 2.x
 *  Redcarpetr >= 2.0.0b5 - see https://github.com/tanoku/redcarpet
+*  Python >= 2.5 && < 3.0 - for pygments (syntax highlighter)
 
 
 Installation

--- a/assets/stylesheets/highlight.css
+++ b/assets/stylesheets/highlight.css
@@ -1,0 +1,112 @@
+/**
+ * Pygments generated.
+ * print(HtmlFormatter(style='default').get_style_defs('.highlight'))
+ */
+
+.highlight .hll { background-color: #ffffcc }
+.highlight  { background: #f8f8f8; }
+.highlight .c { color: #408080; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #008000; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
+.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #B00040 } /* Keyword.Type */
+.highlight .m { color: #666666 } /* Literal.Number */
+.highlight .s { color: #BA2121 } /* Literal.String */
+.highlight .na { color: #7D9029 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.highlight .no { color: #880000 } /* Name.Constant */
+.highlight .nd { color: #AA22FF } /* Name.Decorator */
+.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #0000FF } /* Name.Function */
+.highlight .nl { color: #A0A000 } /* Name.Label */
+.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #19177C } /* Name.Variable */
+.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mf { color: #666666 } /* Literal.Number.Float */
+.highlight .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #008000 } /* Literal.String.Other */
+.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #19177C } /* Name.Variable.Class */
+.highlight .vg { color: #19177C } /* Name.Variable.Global */
+.highlight .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
+
+.syntaxhl .lineno {
+    padding: 2px 4px 2px 4px;
+    background-color: #eee;
+    margin: 0px 5px 0px 0px;
+}
+
+table.highlighttable {
+    margin: 1em 1em 1em 1.6em;
+    border: 2px solid #eee;
+    border-collapse: collapse;
+    width: 97%;
+    background-color: #fafafa;
+}
+
+table.highlighttable tbody {
+    font-family: "Menlo", "Liberation Mono", "Consolas", "Courier New", "andale mono", "lucida console", monospace;
+    font-size: 12px;
+}
+
+table.highlighttable td.linenos {
+    padding: 4px 4px 4px 8px;
+    background: #eee;
+    width: 14px;
+}
+
+table.highlighttable td.linenos pre {
+    background: #eee;
+    text-align: right;
+}
+
+table.highlighttable td.code {
+    border: 0px solid #e2e2e2;
+    padding: 0 8px;
+    background: #fafafa;
+}
+
+table.highlighttable tr td pre {
+    border: 0px solid #e2e2e2;
+    margin: 0px;
+    padding: 0px;
+    white-space: pre;
+    font-size: 12px;
+    line-height: 16px;
+}

--- a/init.rb
+++ b/init.rb
@@ -18,19 +18,25 @@
 require 'redmine'
 require 'redmine/wiki_formatting/markdown/formatter'
 require 'redmine/wiki_formatting/markdown/helper'
+require 'redmine/syntax_highlighting/pygments'
+require 'redcarpet_formatter/pygments_stylesheet_hook'
 
+Rails.configuration.to_prepare do
+  require_dependency 'application_helper'
+  ApplicationHelper.send(:include, RedcarpetFormatter::PygmentsApplicationHelperPatch)
+end
 
 Redmine::Plugin.register :redmine_redcarpet_formatter do
   name 'Redcarpet Markdown Wiki formatter'
   author 'Mikoto Misaka'
   description 'Markdown wiki formatting by Redcarpet for Redmine'
   version '2.1'
+  requires_redmine :version_or_higher => '2.0.0'
 
   wiki_format_provider 'markdown', Redmine::WikiFormatting::Markdown::Formatter, Redmine::WikiFormatting::Markdown::Helper
 
   settings :default => {
     'enable_hardwrap' => '1',
     'enable_no_intra_emphasis' => '1',
-  }, :partial =>'settings/redmine_redcarpet_formatter_settings'
-
+  }, :partial => 'settings/redmine_redcarpet_formatter_settings'
 end

--- a/lib/redcarpet_formatter/pygments_application_helper_patch.rb
+++ b/lib/redcarpet_formatter/pygments_application_helper_patch.rb
@@ -1,0 +1,17 @@
+module RedcarpetFormatter
+  module PygmentsApplicationHelperPatch
+    extend ActiveSupport::Concern
+
+    included do
+      class_eval do
+        alias_method_chain :syntax_highlight_lines, :pygments
+      end
+    end
+
+    def syntax_highlight_lines_with_pygments(name, content)
+      lines = []
+      syntax_highlight(name, content).each_line {|line| lines << "<div class=\"highlight\">#{line}</div>"}
+      lines
+    end
+  end
+end

--- a/lib/redcarpet_formatter/pygments_stylesheet_hook.rb
+++ b/lib/redcarpet_formatter/pygments_stylesheet_hook.rb
@@ -1,0 +1,5 @@
+module RedcarpetFormatter
+  class PygmentsStylesheetHook < Redmine::Hook::ViewListener
+    render_on :view_layouts_base_html_head, :inline => "<%= stylesheet_link_tag 'highlight', :plugin => 'redmine_redcarpet_formatter' %>"
+  end
+end

--- a/lib/redmine/syntax_highlighting/pygments.rb
+++ b/lib/redmine/syntax_highlighting/pygments.rb
@@ -1,0 +1,35 @@
+require 'redmine/syntax_highlighting'
+
+module Redmine
+  module SyntaxHighlighting
+    module Pygments
+      require 'pygments'
+
+      class << self
+        def highlight_by_filename(text, filename)
+          begin
+            opts = {:options => {:encoding => 'utf-8', :nowrap => true}}
+            lexer = ::Pygments.lexer_name_for(:filename => filename)
+            opts[:lexer] = lexer if lexer
+            ::Pygments.highlight(text, opts)
+          rescue
+            ERB::Util.h(text)
+          end
+        end
+
+        def highlight_by_language(text, language)
+          begin
+            opts = {:options => {:encoding => 'utf-8', :linenos => 'table'}}
+            lexer = ::Pygments::Lexer.find(language)
+            opts[:lexer] = lexer[:aliases].first if lexer
+            ::Pygments.highlight(text, opts)
+          rescue
+            ERB::Util.h(text)
+          end
+        end
+      end
+    end
+  end
+
+  SyntaxHighlighting.highlighter = 'Pygments'
+end

--- a/lib/redmine/wiki_formatting/markdown/formatter.rb
+++ b/lib/redmine/wiki_formatting/markdown/formatter.rb
@@ -22,17 +22,19 @@ require 'redcarpet'
 
 class HTMLwithSyntaxHighlighting < ::Redcarpet::Render::HTML
   def block_code(code, language)
-    if language != nil 
-      "<pre>\n<code class='#{language} syntaxhl'>" \
+    if language != nil
+      '<div class="autoscroll">' \
       + Redmine::SyntaxHighlighting.highlight_by_language(code, language) \
-      + "</code>\n</pre>"
-    else 
+      + '</div>'
+    else
       "<pre>\n" + CGI.escapeHTML(code) + "</pre>"
     end
   end
+
   def block_quote(quote)
     "<blockquote>\n" << quote.gsub(/\n([^<])/,'<br>\1') << "</blockquote>\n"
   end
+
   def normal_text(text)
     if !@in_redminelink
       (a, begin_quot, b) = text.partition(':"')
@@ -61,7 +63,7 @@ class HTMLwithSyntaxHighlighting < ::Redcarpet::Render::HTML
       return a
     end
   end
-end  
+end
 
 module Redmine
   module WikiFormatting
@@ -124,13 +126,12 @@ module Redmine
             if line =~ /^(~~~|```)/
               pre = pre == :pre ? :none : :pre
             elsif pre == :none
-              
               level = if line =~ /^(#+)/
                         $1.length
-                      elsif line.strip =~ /^=+$/ 
+                      elsif line.strip =~ /^=+$/
                         line = eval(state).pop + line
                         1
-                      elsif line.strip =~ /^-+$/ 
+                      elsif line.strip =~ /^-+$/
                         line = eval(state).pop + line
                         2
                       else


### PR DESCRIPTION
コードの syntax-highlighting に [pygments.rb](https://github.com/tmm1/pygments.rb) を使うようにしてみました。
python が必要ですが、デフォルトの coderay より対応言語が豊富です。
