### PR TITLE
Fix 'redcarpet' gem conflict and Markdown name clash within Redmine 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem "redcarpet"

--- a/init.rb
+++ b/init.rb
@@ -16,8 +16,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 require 'redmine'
-require 'redmine/wiki_formatting/markdown/formatter'
-require 'redmine/wiki_formatting/markdown/helper'
+require 'redmine/wiki_formatting/redcarpet_markdown/formatter'
+require 'redmine/wiki_formatting/redcarpet_markdown/helper'
 
 
 Redmine::Plugin.register :redmine_redcarpet_formatter do
@@ -26,7 +26,7 @@ Redmine::Plugin.register :redmine_redcarpet_formatter do
   description 'Markdown wiki formatting by Redcarpet for Redmine'
   version '2.1'
 
-  wiki_format_provider 'markdown', Redmine::WikiFormatting::Markdown::Formatter, Redmine::WikiFormatting::Markdown::Helper
+  wiki_format_provider 'redcarpet_markdown', Redmine::WikiFormatting::RedcarpetMarkdown::Formatter, Redmine::WikiFormatting::RedcarpetMarkdown::Helper
 
   settings :default => {
     'enable_hardwrap' => '1',

--- a/lib/redmine/wiki_formatting/redcarpet_markdown/formatter.rb
+++ b/lib/redmine/wiki_formatting/redcarpet_markdown/formatter.rb
@@ -65,7 +65,7 @@ end
 
 module Redmine
   module WikiFormatting
-    module Markdown
+    module RedcarpetMarkdown
       class Formatter
         #    include ActionView::Helpers::TagHelper
 

--- a/lib/redmine/wiki_formatting/redcarpet_markdown/helper.rb
+++ b/lib/redmine/wiki_formatting/redcarpet_markdown/helper.rb
@@ -20,7 +20,7 @@
 module Redmine
   module WikiFormatting
     
-    module Markdown
+    module RedcarpetMarkdown
       module Helper
         unloadable
 


### PR DESCRIPTION
- Gemfile : do not require 'redcarpet', Redmine 2.6 already requires it with specific version (remove whole file)
- Prefix 'markdown' identifiers with redcarpet_ otherwise it clashes with Redmine 2.6 own 'markdown' classes
